### PR TITLE
メモに優先順位機能追加

### DIFF
--- a/src/main/java/com/lesson/memo/controller/MemoController.java
+++ b/src/main/java/com/lesson/memo/controller/MemoController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.lesson.memo.model.Memo;
-import com.lesson.memo.model.Priority;
 import com.lesson.memo.repository.MemoRepository;
 
 @Controller
@@ -43,7 +42,7 @@ public class MemoController {
     @GetMapping("/new")
     public String showForm(Model model) {
         model.addAttribute("memo", new Memo());
-        model.addAttribute("priorities", Priority.values()); 
+        model.addAttribute("priorities", Memo.Priority.values()); 
         return "memo-form";
     }
 
@@ -51,7 +50,7 @@ public class MemoController {
     public String create(@ModelAttribute @Valid Memo memo,
                          BindingResult result, Model model) {
         if (result.hasErrors()) {
-            model.addAttribute("priorities", Priority.values());
+            model.addAttribute("priorities", Memo.Priority.values());
             return "memo-form";
         }
 
@@ -77,14 +76,14 @@ public class MemoController {
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable Long id, Model model, HttpServletResponse response) {
         if (model.containsAttribute("memo")) {
-            model.addAttribute("priorities", Priority.values());
+            model.addAttribute("priorities", Memo.Priority.values());
             return "memo-form";
         }
 
         return memoRepository.findById(id)
                 .map(memo -> {
                     model.addAttribute("memo", memo);
-                    model.addAttribute("priorities", Priority.values()); 
+                    model.addAttribute("priorities", Memo.Priority.values()); 
                     return "memo-form";
                 })
                 .orElseGet(() -> {
@@ -110,7 +109,7 @@ public class MemoController {
         Memo memoToUpdate = opt.get();
 
         if (result.hasErrors()) {
-            model.addAttribute("priorities", Priority.values());
+            model.addAttribute("priorities", Memo.Priority.values());
             redirectAttributes.addFlashAttribute("org.springframework.validation.BindingResult.memo", result);
             redirectAttributes.addFlashAttribute("memo", memo);
             return "redirect:/memo/edit/" + id;

--- a/src/main/java/com/lesson/memo/model/Memo.java
+++ b/src/main/java/com/lesson/memo/model/Memo.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -28,6 +29,19 @@ public class Memo {
     @NotBlank(message = "内容を入力してください")
     @Column(nullable = false, length = 1000)
     private String content;
+    
+    @NotNull(message = "優先度を選択してください")
+    private Priority priority;
+    
+    public enum Priority {
+        HIGH("高"),
+        MEDIUM("中"),
+        LOW("低");
+
+        private final String label;
+        Priority(String label) { this.label = label; }
+        public String getLabel() { return label; }
+    }
 
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
@@ -35,7 +49,6 @@ public class Memo {
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
     
-    @Column(nullable = false)
-    private Priority priority;
+   
 
 }

--- a/src/main/java/com/lesson/memo/model/Memo.java
+++ b/src/main/java/com/lesson/memo/model/Memo.java
@@ -4,8 +4,6 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -36,26 +34,8 @@ public class Memo {
 
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
-
-    // 追加：優先度フィールド
-    @Enumerated(EnumType.STRING)
+    
     @Column(nullable = false)
     private Priority priority;
-}
 
-// Priority enum は別ファイルにしてもOKですが、同じファイルに書く場合
-enum Priority {
-    HIGH("高"),
-    MEDIUM("中"),
-    LOW("低");
-
-    private final String label;
-
-    Priority(String label) {
-        this.label = label;
-    }
-
-    public String getLabel() {
-        return label;
-    }
 }

--- a/src/main/java/com/lesson/memo/model/Memo.java
+++ b/src/main/java/com/lesson/memo/model/Memo.java
@@ -2,14 +2,17 @@ package com.lesson.memo.model;
 
 import java.time.LocalDateTime;
 
-import org.springframework.format.annotation.DateTimeFormat;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotBlank;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
 import lombok.Data;
 
 @Entity
@@ -33,4 +36,26 @@ public class Memo {
 
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
+
+    // 追加：優先度フィールド
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Priority priority;
+}
+
+// Priority enum は別ファイルにしてもOKですが、同じファイルに書く場合
+enum Priority {
+    HIGH("高"),
+    MEDIUM("中"),
+    LOW("低");
+
+    private final String label;
+
+    Priority(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -531,3 +531,24 @@ textarea {
 .priority-pill.low:has(.priority-radio:checked) {
   background:#198754; color:#fff;
 }
+
+.badge-high {
+    background-color: red;
+    color: white;
+    padding: 2px 6px;
+    border-radius: 4px;
+}
+
+.badge-medium {
+    background-color: orange;
+    color: white;
+    padding: 2px 6px;
+    border-radius: 4px;
+}
+
+.badge-low {
+    background-color: green;
+    color: white;
+    padding: 2px 6px;
+    border-radius: 4px;
+}

--- a/src/main/resources/templates/memo-detail.html
+++ b/src/main/resources/templates/memo-detail.html
@@ -2,44 +2,48 @@
 <html xmlns:th="http://www.thymeleaf.org">
 
 <head>
-    <meta charset="UTF-8">
-    <title>メモ詳細</title>
-    <link rel="stylesheet" th:href="@{/css/style.css}">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@3.5.0/fonts/remixicon.css">
+	<meta charset="UTF-8">
+	<title>メモ詳細</title>
+	<link rel="stylesheet" th:href="@{/css/style.css}">
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@3.5.0/fonts/remixicon.css">
 </head>
 
 <body>
-    <div class="container">
-        <div class="header">
-            <h1 class="app-title">メモ詳細</h1>
-            <a th:href="@{/memo}" class="btn btn-outline"><i class="ri-arrow-left-line"></i> 戻る</a>
-        </div>
-        <div class="note-card note-card-large">
-            <div class="note-card-header">
-                <h2 class="note-card-title" th:text="${memo.title}">タイトル</h2>
-            </div>
-            <div class="note-card-content">
-                <p class="note-card-text" th:text="${memo.content}">本文</p>
-            </div>
-
-            <!-- 追加：優先度表示 -->
-            <div class="note-card-priority">
-                <p>優先度: <span th:text="${memo.priority.label}">高/中/低</span></p>
-            </div>
-
-            <div class="note-card-footer detail-footer">
-                <p class="note-date" th:text="${#temporals.format(memo.createdAt, 'yyyy/MM/dd HH:mm')}">作成日時</p>
-                <div class="note-actions">
-                    <a th:href="@{|/memo/edit/${memo.id}|}" class="btn btn-primary">編集</a>
-                    <a th:href="@{|/memo/delete/${memo.id}|}" class="btn btn-danger">
-                        削除
-                    </a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <script th:src="@{/js/common.js}"></script>
+	<div class="container">
+		<div class="header">
+		<h1 class="app-title">メモ詳細</h1>
+		<a th:href="@{/memo}" class="btn btn-outline"><i class="ri-arrow-left-line"></i> 戻る</a>
+		</div>
+		
+		<div class="note-card note-card-large">
+			<div class="note-card-header">
+			<h2 class="note-card-title" th:text="${memo.title}">タイトル</h2>
+			</div>
+			
+			<div class="note-card-content">
+				<p class="note-card-text" th:text="${memo.content}">本文</p>
+			</div>
+			
+			<div class="note-card-priority">
+				<p>優先度:
+				<span th:if="${memo.priority != null}"
+				      th:class="'note-badge ' + ${memo.priority.name().toLowerCase()}"
+				      th:text="${memo.priority.getLabel()}">
+				</span>
+				</p>
+			</div>
+			
+			<div class="note-card-footer detail-footer">
+				<p class="note-date" th:text="${memo.createdAt != null ? #temporals.format(memo.createdAt, 'yyyy/MM/dd HH:mm') : ''}">作成日時</p>
+			<div class="note-actions">
+				<a th:href="@{'/memo/edit/' + ${memo.id}}" class="btn btn-primary">編集</a>
+				<a th:href="@{'/memo/delete/' + ${memo.id}}" class="btn btn-danger">削除</a>
+			</div>
+			</div>
+		</div>
+	</div>
+	<script th:src="@{/js/common.js}"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/memo-detail.html
+++ b/src/main/resources/templates/memo-detail.html
@@ -23,6 +23,11 @@
                 <p class="note-card-text" th:text="${memo.content}">本文</p>
             </div>
 
+            <!-- 追加：優先度表示 -->
+            <div class="note-card-priority">
+                <p>優先度: <span th:text="${memo.priority.label}">高/中/低</span></p>
+            </div>
+
             <div class="note-card-footer detail-footer">
                 <p class="note-date" th:text="${#temporals.format(memo.createdAt, 'yyyy/MM/dd HH:mm')}">作成日時</p>
                 <div class="note-actions">

--- a/src/main/resources/templates/memo-form.html
+++ b/src/main/resources/templates/memo-form.html
@@ -31,6 +31,15 @@
                     <div th:if="${#fields.hasErrors('content')}" th:errors="*{content}" class="error-message"></div>
                 </div>
 
+                <!-- 追加：優先度選択 -->
+                <div class="form-group">
+                    <label>優先度：</label>
+                    <select th:field="*{priority}">
+                        <option th:each="p : ${priorities}" th:value="${p}" th:text="${p.label}"></option>
+                    </select>
+                    <div th:if="${#fields.hasErrors('priority')}" th:errors="*{priority}" class="error-message"></div>
+                </div>
+
                 <div class="form-button-container">
                     <button type="submit" class="btn btn-primary" th:text="${memo.id} != null ? '更新' : '作成'">作成</button>
                 </div>

--- a/src/main/resources/templates/memo-form.html
+++ b/src/main/resources/templates/memo-form.html
@@ -20,23 +20,32 @@
         <div class="note-form-card">
             <form th:action="${memo.id} != null ? @{|/memo/update/${memo.id}|} : @{/memo/create}" th:object="${memo}" method="post">        
                 <div class="form-group">
-                    <label>タイトル：</label>
-                    <input type="text" th:field="*{title}">
+                    <label for="title-input">タイトル：</label>
+                    <input type="text" id="title-input" th:field="*{title}">
                     <div th:if="${#fields.hasErrors('title')}" th:errors="*{title}" class="error-message"></div>
                 </div>
 
                 <div class="form-group">
-                    <label>内容：</label>
-                    <textarea th:field="*{content}"></textarea>
+                    <label for="content-textarea">内容：</label>
+                    <textarea id="content-textarea" th:field="*{content}"></textarea>
                     <div th:if="${#fields.hasErrors('content')}" th:errors="*{content}" class="error-message"></div>
                 </div>
 
-                <!-- 追加：優先度選択 -->
                 <div class="form-group">
                     <label>優先度：</label>
-                    <select th:field="*{priority}">
-                        <option th:each="p : ${priorities}" th:value="${p}" th:text="${p.label}"></option>
-                    </select>
+                    <div class="priority-group">
+                        <label th:each="p : ${priorities}" 
+                               th:for="${'priority-' + p.name()}"
+                               class="priority-pill" 
+                               th:classappend="${p.name().toLowerCase()}">
+                            <input type="radio" 
+                                   class="priority-radio"
+                                   th:id="${'priority-' + p.name()}"
+                                   th:field="*{priority}" 
+                                   th:value="${p}">
+                            <span th:text="${p.label}"></span>
+                        </label>
+                    </div>
                     <div th:if="${#fields.hasErrors('priority')}" th:errors="*{priority}" class="error-message"></div>
                 </div>
 
@@ -48,5 +57,4 @@
     </div>
     <script th:src="@{/js/common.js}"></script>
 </body>
-
 </html>

--- a/src/main/resources/templates/memo-list.html
+++ b/src/main/resources/templates/memo-list.html
@@ -2,50 +2,51 @@
 <html xmlns:th="http://www.thymeleaf.org">
 
 <head>
-    <meta charset="UTF-8">
-    <title>メモ一覧</title>
-    <link rel="stylesheet" th:href="@{/css/style.css}">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@3.5.0/fonts/remixicon.css">
+	<meta charset="UTF-8">
+	<title>メモ一覧</title>
+	<link rel="stylesheet" th:href="@{/css/style.css}">
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@3.5.0/fonts/remixicon.css">
 </head>
 
 <body>
-    <div class="container">
-        <div class="header">
-            <h1 class="app-title">メモ一覧</h1>
-            <a th:href="@{/memo/new}" class="btn btn-primary">
-                <i class="ri-add-circle-line"></i> 新規メモ
-            </a>
-        </div>
-
-        <div class="notes-grid">
-            <div class="note-card" th:each="memo : ${memos}">
-                <div class="note-card-header">
-                    <h3 class="note-card-title" th:text="${memo.title}">タイトル</h3>
-                    <!-- 追加：優先度表示 -->
-                    <span class="note-priority" th:text="${memo.priority.label}">高/中/低</span>
-                </div>
-                <div class="note-card-content">
-                    <p class="note-card-text" th:text="${memo.content}">内容</p>
-                </div>
-                <div class="note-card-footer">
-                    <p class="note-date" th:text="${#temporals.format(memo.createdAt, 'yyyy/MM/dd HH:mm')}">日付</p>
-                    <div class="note-actions">
-                        <a th:href="@{|/memo/detail/${memo.id}|}" class="btn btn-primary">詳細</a>
-                        <a th:href="@{|/memo/delete/${memo.id}|}" class="btn btn-danger">
-                            削除
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div th:if="${memos.isEmpty()}" class="empty-state">
-            <p>メモがありません</p>
-            <a th:href="@{/memo/new}" class="btn btn-primary">新しいメモを作成</a>
-        </div>
-    </div>
-    <script th:src="@{/js/common.js}"></script>
+	<div class="container">
+	<div class="header">
+	<h1 class="app-title">メモ一覧</h1>
+		<a th:href="@{/memo/new}" class="btn btn-primary">
+		<i class="ri-add-circle-line"></i> 新規メモ
+	</a>
+	</div>
+	
+	<div class="notes-grid" th:if="${memos != null && memos.size() > 0}">
+	<div class="note-card" th:each="memo : ${memos}">
+	<div class="note-card-header">
+		<h3 class="note-card-title" th:text="${memo.title}">タイトル</h3>
+			<span th:if="${memo.priority != null}" 
+		      th:class="'note-badge ' + ${memo.priority.name().toLowerCase()}"
+		      th:text="${memo.priority.label}">
+			</span>
+	</div>
+	
+	<div class="note-card-content">
+		<p class="note-card-text" th:text="${memo.content}">内容</p>
+	</div>
+		<div class="note-card-footer">
+			<p class="note-date" th:text="${memo.createdAt != null ? #temporals.format(memo.createdAt, 'yyyy/MM/dd HH:mm') : ''}">日付</p>
+			<div class="note-actions">
+				<a th:href="@{'/memo/detail/' + ${memo.id}}" class="btn btn-primary">詳細</a>
+				<a th:href="@{'/memo/delete/' + ${memo.id}}" class="btn btn-danger">削除</a>
+			</div>
+		</div>
+	</div>
+	</div>
+	
+	<div th:if="${memos == null || memos.size() == 0}" class="empty-state">
+		<p>メモがありません</p>
+		<a th:href="@{/memo/new}" class="btn btn-primary">新しいメモを作成</a>
+	</div>
+	</div>
+	<script th:src="@{/js/common.js}"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/memo-list.html
+++ b/src/main/resources/templates/memo-list.html
@@ -22,6 +22,8 @@
             <div class="note-card" th:each="memo : ${memos}">
                 <div class="note-card-header">
                     <h3 class="note-card-title" th:text="${memo.title}">タイトル</h3>
+                    <!-- 追加：優先度表示 -->
+                    <span class="note-priority" th:text="${memo.priority.label}">高/中/低</span>
                 </div>
                 <div class="note-card-content">
                     <p class="note-card-text" th:text="${memo.content}">内容</p>


### PR DESCRIPTION
## 概要
メモに「優先度（高・中・低）」を設定できる機能を追加しました。

## 主な変更点
- Priority enum を追加
- Memo エンティティに priority フィールドを追加
- 新規作成・編集フォームに優先度選択ボタンを追加
- 一覧・詳細画面に優先度バッジを表示
- 一覧を「高→中→低」の順でソート

## 確認方法
1. 新規作成画面で優先度を選択して保存
2. 編集画面で優先度を変更して保存
3. 一覧・詳細画面に正しく表示されることを確認
4. 一覧が優先度順になっていることを確認