### PR TITLE
メモに優先順位機能追加

### DIFF
--- a/src/main/java/com/lesson/memo/controller/MemoController.java
+++ b/src/main/java/com/lesson/memo/controller/MemoController.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -16,10 +19,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.lesson.memo.model.Memo;
+import com.lesson.memo.model.Priority;
 import com.lesson.memo.repository.MemoRepository;
-
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 
 @Controller
 @RequestMapping("/memo")
@@ -30,7 +31,7 @@ public class MemoController {
 
     @GetMapping
     public String list(Model model) {
-        List<Memo> memos = memoRepository.findAll();
+    	List<Memo> memos = memoRepository.findAllByOrderByPriorityAsc();
         model.addAttribute("memos", memos);
         return "memo-list";
     }
@@ -38,6 +39,7 @@ public class MemoController {
     @GetMapping("/new")
     public String showForm(Model model) {
         model.addAttribute("memo", new Memo());
+        model.addAttribute("priorities", Priority.values());
         return "memo-form";
     }
 
@@ -76,6 +78,7 @@ public class MemoController {
         return memoRepository.findById(id)
                 .map(memo -> {
                     model.addAttribute("memo", memo);
+                    model.addAttribute("priorities", Priority.values());
                     return "memo-form";
                 })
                 .orElseGet(() -> {
@@ -106,6 +109,7 @@ public class MemoController {
         }
 
         memoToUpdate.setTitle(memo.getTitle());
+        memoToUpdate.setPriority(memo.getPriority());
         memoToUpdate.setContent(memo.getContent());
         memoToUpdate.setUpdatedAt(LocalDateTime.now());
         memoRepository.save(memoToUpdate);

--- a/src/main/java/com/lesson/memo/model/Memo.java
+++ b/src/main/java/com/lesson/memo/model/Memo.java
@@ -2,14 +2,15 @@ package com.lesson.memo.model;
 
 import java.time.LocalDateTime;
 
-import org.springframework.format.annotation.DateTimeFormat;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotBlank;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
 import lombok.Data;
 
 @Entity
@@ -33,4 +34,6 @@ public class Memo {
 
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
+    
+    private Priority priority;
 }

--- a/src/main/java/com/lesson/memo/repository/MemoRepository.java
+++ b/src/main/java/com/lesson/memo/repository/MemoRepository.java
@@ -1,9 +1,11 @@
 package com.lesson.memo.repository;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.lesson.memo.model.Memo;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
+	List<Memo> findAllByOrderByPriorityAsc();
     
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -473,7 +473,7 @@ textarea {
 }
 
 .note-badge.high   { background:#dc3545; color:#fff; }
-.note-badge.medium { background:#ffc107; color:#212529; }
+.note-badge.middle { background:#ffc107; color:#212529; }
 .note-badge.low    { background:#198754; color:#fff; }
 
 /* ラジオグループ全体 */
@@ -514,7 +514,7 @@ textarea {
 
 /* デフォは薄めの色 */
 .priority-pill.high   { background:#f8d7da; color:#721c24; }
-.priority-pill.medium { background:#fff3cd; color:#856404; }
+.priority-pill.middle { background:#fff3cd; color:#856404; }
 .priority-pill.low    { background:#d4edda; color:#155724; }
 
 /* 選択中 */
@@ -525,7 +525,7 @@ textarea {
 .priority-pill.high:has(.priority-radio:checked) {
   background:#dc3545; color:#fff;
 }
-.priority-pill.medium:has(.priority-radio:checked) {
+.priority-pill.middle:has(.priority-radio:checked) {
   background:#ffc107; color:#212529;
 }
 .priority-pill.low:has(.priority-radio:checked) {

--- a/src/main/resources/templates/memo-detail.html
+++ b/src/main/resources/templates/memo-detail.html
@@ -18,6 +18,11 @@
         <div class="note-card note-card-large">
             <div class="note-card-header">
                 <h2 class="note-card-title" th:text="${memo.title}">タイトル</h2>
+				<div class="note-badge"
+					 th:text="${memo.priority.label}"
+					 th:classappend="${#strings.toLowerCase(memo.priority)}">
+					 優先度
+				</div>
             </div>
             <div class="note-card-content">
                 <p class="note-card-text" th:text="${memo.content}">本文</p>

--- a/src/main/resources/templates/memo-form.html
+++ b/src/main/resources/templates/memo-form.html
@@ -24,6 +24,23 @@
                     <input type="text" th:field="*{title}">
                     <div th:if="${#fields.hasErrors('title')}" th:errors="*{title}" class="error-message"></div>
                 </div>
+				
+				<div class="form-group">
+					<label>優先度</label>
+					<div class="priority-group">
+					    <label th:each="p : ${priorities}" 
+					           class="priority-pill" 
+					           th:classappend="${#strings.toLowerCase(p)}">
+					        
+					        <input type="radio" 
+					               th:field="*{priority}" 
+					               th:value="${p}" 
+					               class="priority-radio">
+					        
+					        <span th:text="${p.label}">高</span>
+					    </label>
+					</div>
+				</div>
 
                 <div class="form-group">
                     <label>内容：</label>

--- a/src/main/resources/templates/memo-list.html
+++ b/src/main/resources/templates/memo-list.html
@@ -22,7 +22,12 @@
             <div class="note-card" th:each="memo : ${memos}">
                 <div class="note-card-header">
                     <h3 class="note-card-title" th:text="${memo.title}">タイトル</h3>
-                </div>
+					<div class="note-badge"
+					     th:text="${memo.priority.label}"
+						 th:classappend="${#strings.toLowerCase(memo.priority)}">
+						 優先度
+					 </div>
+				</div>
                 <div class="note-card-content">
                     <p class="note-card-text" th:text="${memo.content}">内容</p>
                 </div>


### PR DESCRIPTION
## 概要
メモに「優先度（高・中・低）」を設定できる機能を追加しました。

## 主な変更点
- Priority enum を追加
- Memo エンティティに priority フィールドを追加
- 新規作成・編集フォームに優先度選択ボタンを追加
- 一覧・詳細画面に優先度バッジを表示
- 一覧を「高→中→低」の順でソート

## 確認方法
1. 新規作成画面で優先度を選択して保存
2. 編集画面で優先度を変更して保存
3. 一覧・詳細画面に正しく表示されることを確認
4. 一覧が優先度順になっていることを確認